### PR TITLE
Add dark mode feature with theme toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.1",
         "@tailwindcss/postcss": "^4.1.18",
-        "@types/node": "^24.10.1",
+        "@types/node": "^24.10.9",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@tailwindcss/postcss": "^4.1.18",
-    "@types/node": "^24.10.1",
+    "@types/node": "^24.10.9",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Header } from './components/Header';
 import { FeaturedSection } from './components/Featured';
 import { AccordionList } from './components/Accordion';
+import { ThemeProvider } from './context';
 import { featuredItems } from './data/featuredItems';
 import { accordionItems } from './data/accordionItems';
 
@@ -12,36 +13,38 @@ class App extends Component {
 
   render(): React.ReactNode {
     return (
-      <div className="min-h-screen bg-gray-100">
-        {/* Mobile Container */}
-        <div className="max-w-mobile mx-auto bg-white min-h-screen shadow-lg">
-          {/* Skip Link for Keyboard Navigation */}
-          <a
-            href="#main-content"
-            className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-tokopedia-green focus:text-white focus:rounded"
-          >
-            Skip to main content
-          </a>
+      <ThemeProvider>
+        <div className="min-h-screen bg-gray-100 dark:bg-dark-bg-primary">
+          {/* Mobile Container */}
+          <div className="max-w-mobile mx-auto bg-white dark:bg-dark-bg-secondary min-h-screen shadow-lg">
+            {/* Skip Link for Keyboard Navigation */}
+            <a
+              href="#main-content"
+              className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-tokopedia-green focus:text-white focus:rounded"
+            >
+              Skip to main content
+            </a>
 
-          {/* Header */}
-          <Header
-            title="Jelajah Tokopedia"
-            onBackClick={this.handleBackClick}
-          />
-
-          {/* Main Content */}
-          <main id="main-content" aria-label="Main content">
-            {/* Featured Section */}
-            <FeaturedSection
-              title="Featured"
-              items={featuredItems}
+            {/* Header */}
+            <Header
+              title="Jelajah Tokopedia"
+              onBackClick={this.handleBackClick}
             />
 
-            {/* Accordion Categories */}
-            <AccordionList items={accordionItems} />
-          </main>
+            {/* Main Content */}
+            <main id="main-content" aria-label="Main content">
+              {/* Featured Section */}
+              <FeaturedSection
+                title="Featured"
+                items={featuredItems}
+              />
+
+              {/* Accordion Categories */}
+              <AccordionList items={accordionItems} />
+            </main>
+          </div>
         </div>
-      </div>
+      </ThemeProvider>
     );
   }
 }

--- a/src/components/Accordion/AccordionItem.tsx
+++ b/src/components/Accordion/AccordionItem.tsx
@@ -13,12 +13,12 @@ class AccordionItem extends Component<AccordionItemProps> {
     const contentId = `accordion-content-${id}`;
 
     return (
-      <div className="border-b border-gray-100">
+      <div className="border-b border-gray-100 dark:border-dark-border">
         {/* Accordion Header */}
         <button
           type="button"
           onClick={this.handleClick}
-          className="flex items-center justify-between w-full min-h-[56px] px-4 py-4 hover:bg-gray-50 active:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-tokopedia-green"
+          className="flex items-center justify-between w-full min-h-[56px] px-4 py-4 hover:bg-gray-50 dark:hover:bg-dark-bg-tertiary active:bg-gray-100 dark:active:bg-dark-bg-primary transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-tokopedia-green"
           aria-expanded={isExpanded}
           aria-controls={contentId}
         >
@@ -30,13 +30,13 @@ class AccordionItem extends Component<AccordionItemProps> {
                 className="w-6 h-6 text-tokopedia-green"
               />
             )}
-            <span className="text-base font-semibold text-gray-900">
+            <span className="text-base font-semibold text-gray-900 dark:text-dark-text-primary">
               {title}
             </span>
           </div>
           <ChevronIcon
             direction={isExpanded ? 'up' : 'down'}
-            className="w-5 h-5 text-gray-500"
+            className="w-5 h-5 text-gray-500 dark:text-dark-text-secondary"
           />
         </button>
 

--- a/src/components/Accordion/AccordionList.tsx
+++ b/src/components/Accordion/AccordionList.tsx
@@ -23,9 +23,9 @@ class AccordionList extends Component<AccordionListProps, AccordionListState> {
 
     return (
       <nav aria-label="Category navigation">
-        <div className="bg-white" role="list">
+        <div className="bg-white dark:bg-dark-bg-secondary" role="list">
           {items.length === 0 ? (
-            <div className="px-4 py-8 text-center text-gray-500">
+            <div className="px-4 py-8 text-center text-gray-500 dark:text-dark-text-secondary">
               No categories available
             </div>
           ) : (
@@ -39,7 +39,7 @@ class AccordionList extends Component<AccordionListProps, AccordionListState> {
                 onToggle={this.handleToggle}
               >
                 {item.children && item.children.length > 0 && (
-                  <div className="grid grid-cols-4 gap-4">
+                  <div className="grid grid-cols-4 gap-4 bg-gray-50 dark:bg-dark-bg-primary p-4 rounded-lg">
                     {item.children.map((child) => (
                       <IconCard
                         key={child.id}

--- a/src/components/Featured/FeaturedSection.tsx
+++ b/src/components/Featured/FeaturedSection.tsx
@@ -22,21 +22,21 @@ class FeaturedSection extends Component<FeaturedSectionProps, FeaturedSectionSta
     const { isExpanded } = this.state;
 
     return (
-      <section className="bg-white">
+      <section className="bg-white dark:bg-dark-bg-secondary">
         {/* Section Header */}
         <button
           type="button"
           onClick={this.handleToggle}
-          className="flex items-center justify-between w-full px-4 py-3 hover:bg-gray-50 active:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-tokopedia-green"
+          className="flex items-center justify-between w-full px-4 py-3 hover:bg-gray-50 dark:hover:bg-dark-bg-tertiary active:bg-gray-100 dark:active:bg-dark-bg-primary transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-tokopedia-green"
           aria-expanded={isExpanded}
           aria-controls="featured-content"
         >
-          <h2 className="text-base font-semibold text-gray-900">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-dark-text-primary">
             {title}
           </h2>
           <ChevronIcon
             direction={isExpanded ? 'up' : 'down'}
-            className="w-5 h-5 text-gray-500"
+            className="w-5 h-5 text-gray-500 dark:text-dark-text-secondary"
           />
         </button>
 
@@ -59,7 +59,7 @@ class FeaturedSection extends Component<FeaturedSectionProps, FeaturedSectionSta
         </div>
 
         {/* Bottom Border */}
-        <div className="h-2 bg-gray-100" />
+        <div className="h-2 bg-gray-100 dark:bg-dark-border" />
       </section>
     );
   }

--- a/src/components/Featured/IconCard.tsx
+++ b/src/components/Featured/IconCard.tsx
@@ -23,7 +23,7 @@ class IconCard extends Component<IconCardProps, IconCardState> {
 
     if (imageError) {
       return (
-        <div className="w-8 h-8 flex items-center justify-center bg-gray-300 rounded text-gray-600 text-xs font-semibold">
+        <div className="w-8 h-8 flex items-center justify-center bg-gray-300 dark:bg-dark-bg-primary rounded text-gray-600 dark:text-dark-text-secondary text-xs font-semibold">
           ?
         </div>
       );
@@ -48,12 +48,12 @@ class IconCard extends Component<IconCardProps, IconCardState> {
         type="button"
         onClick={this.handleClick}
         aria-label={label}
-        className="flex flex-col items-center group cursor-pointer bg-transparent border-none p-0 min-h-[88px] focus:outline-none focus:ring-2 focus:ring-tokopedia-green focus:ring-offset-2 rounded-2xl active:bg-gray-200"
+        className="flex flex-col items-center group cursor-pointer bg-transparent border-none p-0 min-h-[88px] focus:outline-none focus:ring-2 focus:ring-tokopedia-green focus:ring-offset-2 rounded-2xl active:bg-gray-200 dark:active:bg-dark-bg-primary"
       >
-        <div className="w-16 h-16 flex items-center justify-center bg-gray-50 rounded-2xl mb-2 group-hover:bg-gray-100 transition-colors">
+        <div className="w-16 h-16 flex items-center justify-center bg-gray-50 dark:bg-dark-bg-tertiary rounded-2xl mb-2 group-hover:bg-gray-100 dark:group-hover:bg-dark-bg-primary transition-colors">
           {this.renderIcon()}
         </div>
-        <span className="text-xs text-gray-700 text-center leading-tight max-w-20">
+        <span className="text-xs text-gray-700 dark:text-dark-text-secondary text-center leading-tight max-w-20">
           {label}
         </span>
       </button>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,8 +1,11 @@
 import React, { Component } from 'react';
 import type { HeaderProps } from '../../types';
-import { BackArrowIcon } from '../common';
+import { BackArrowIcon, MoonIcon, SunIcon } from '../common';
+import { ThemeContext } from '../../context';
 
 class Header extends Component<HeaderProps> {
+  static contextType = ThemeContext;
+  declare context: React.ContextType<typeof ThemeContext>;
   handleBackClick = (): void => {
     const { onBackClick } = this.props;
     if (onBackClick) {
@@ -10,23 +13,42 @@ class Header extends Component<HeaderProps> {
     }
   };
 
+  handleThemeToggle = (): void => {
+    this.context.toggleTheme();
+  };
+
   render(): React.ReactNode {
     const { title } = this.props;
+    const { theme } = this.context;
 
     return (
-      <header className="sticky top-0 z-10 bg-white border-b border-gray-100">
-        <div className="flex items-center h-14 px-4">
+      <header className="sticky top-0 z-10 bg-white dark:bg-dark-bg-secondary border-b border-gray-100 dark:border-dark-border">
+        <div className="flex items-center justify-between h-14 px-4">
+          <div className="flex items-center">
+            <button
+              type="button"
+              onClick={this.handleBackClick}
+              className="flex items-center justify-center w-11 h-11 -ml-2 rounded-full hover:bg-gray-100 dark:hover:bg-dark-bg-tertiary active:bg-gray-200 dark:active:bg-dark-bg-primary focus:outline-none focus:ring-2 focus:ring-tokopedia-green focus:ring-offset-2 transition-colors"
+              aria-label="Go back"
+            >
+              <BackArrowIcon className="w-6 h-6 text-gray-800 dark:text-dark-text-primary" />
+            </button>
+            <h1 className="ml-2 text-lg font-semibold text-gray-900 dark:text-dark-text-primary">
+              {title}
+            </h1>
+          </div>
           <button
             type="button"
-            onClick={this.handleBackClick}
-            className="flex items-center justify-center w-11 h-11 -ml-2 rounded-full hover:bg-gray-100 active:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-tokopedia-green focus:ring-offset-2 transition-colors"
-            aria-label="Go back"
+            onClick={this.handleThemeToggle}
+            className="flex items-center justify-center w-10 h-10 rounded-full hover:bg-gray-100 dark:hover:bg-dark-bg-tertiary active:bg-gray-200 dark:active:bg-dark-bg-primary focus:outline-none focus:ring-2 focus:ring-tokopedia-green focus:ring-offset-2 transition-colors"
+            aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
           >
-            <BackArrowIcon className="w-6 h-6 text-gray-800" />
+            {theme === 'light' ? (
+              <MoonIcon className="w-5 h-5 text-gray-700 dark:text-dark-text-secondary" />
+            ) : (
+              <SunIcon className="w-5 h-5 text-gray-700 dark:text-dark-text-secondary" />
+            )}
           </button>
-          <h1 className="ml-2 text-lg font-semibold text-gray-900">
-            {title}
-          </h1>
         </div>
       </header>
     );

--- a/src/components/common/MoonIcon.tsx
+++ b/src/components/common/MoonIcon.tsx
@@ -1,0 +1,31 @@
+import { Component } from 'react';
+
+interface MoonIconProps {
+  className?: string;
+}
+
+class MoonIcon extends Component<MoonIconProps> {
+  render(): React.ReactNode {
+    const { className = '' } = this.props;
+
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={className}
+        aria-hidden="true"
+      >
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+      </svg>
+    );
+  }
+}
+
+export default MoonIcon;

--- a/src/components/common/SunIcon.tsx
+++ b/src/components/common/SunIcon.tsx
@@ -1,0 +1,39 @@
+import { Component } from 'react';
+
+interface SunIconProps {
+  className?: string;
+}
+
+class SunIcon extends Component<SunIconProps> {
+  render(): React.ReactNode {
+    const { className = '' } = this.props;
+
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={className}
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="5" />
+        <line x1="12" y1="1" x2="12" y2="3" />
+        <line x1="12" y1="21" x2="12" y2="23" />
+        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+        <line x1="1" y1="12" x2="3" y2="12" />
+        <line x1="21" y1="12" x2="23" y2="12" />
+        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+      </svg>
+    );
+  }
+}
+
+export default SunIcon;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,2 +1,4 @@
 export { default as ChevronIcon } from './ChevronIcon';
 export { default as BackArrowIcon } from './BackArrowIcon';
+export { default as MoonIcon } from './MoonIcon';
+export { default as SunIcon } from './SunIcon';

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -54,11 +54,8 @@ export class ThemeProvider extends Component<ThemeProviderProps, ThemeProviderSt
   // Apply theme class to document element
   applyTheme = (theme: Theme): void => {
     const root = document.documentElement;
-    if (theme === 'dark') {
-      root.classList.add('dark');
-    } else {
-      root.classList.remove('dark');
-    }
+    // Use toggle with force parameter for more reliable class management
+    root.classList.toggle('dark', theme === 'dark');
   };
 
   // Save theme to localStorage

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,101 @@
+import React, { Component, createContext } from 'react';
+import type { Theme, ThemeContextType } from '../types';
+
+// Create the context with default values
+export const ThemeContext = createContext<ThemeContextType>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+}
+
+interface ThemeProviderState {
+  theme: Theme;
+}
+
+// ThemeProvider class component
+export class ThemeProvider extends Component<ThemeProviderProps, ThemeProviderState> {
+  constructor(props: ThemeProviderProps) {
+    super(props);
+
+    // Get initial theme from localStorage or system preference
+    const savedTheme = this.getSavedTheme();
+
+    this.state = {
+      theme: savedTheme,
+    };
+
+    // Apply theme class to document on initialization
+    this.applyTheme(savedTheme);
+  }
+
+  // Get saved theme from localStorage or fall back to system preference
+  getSavedTheme = (): Theme => {
+    try {
+      const saved = localStorage.getItem('replicate-ui-theme') as Theme | null;
+      if (saved === 'light' || saved === 'dark') {
+        return saved;
+      }
+    } catch (e) {
+      // localStorage might not be available
+      console.warn('Failed to read theme from localStorage:', e);
+    }
+
+    // Fall back to system preference
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark';
+    }
+
+    return 'light';
+  };
+
+  // Apply theme class to document element
+  applyTheme = (theme: Theme): void => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  };
+
+  // Save theme to localStorage
+  saveTheme = (theme: Theme): void => {
+    try {
+      localStorage.setItem('replicate-ui-theme', theme);
+    } catch (e) {
+      console.warn('Failed to save theme to localStorage:', e);
+    }
+  };
+
+  // Toggle theme between light and dark
+  toggleTheme = (): void => {
+    this.setState(
+      (prevState) => ({
+        theme: prevState.theme === 'light' ? 'dark' : 'light',
+      }),
+      () => {
+        this.applyTheme(this.state.theme);
+        this.saveTheme(this.state.theme);
+      }
+    );
+  };
+
+  render(): React.ReactNode {
+    const { children } = this.props;
+    const { theme } = this.state;
+
+    const contextValue: ThemeContextType = {
+      theme,
+      toggleTheme: this.toggleTheme,
+    };
+
+    return (
+      <ThemeContext.Provider value={contextValue}>
+        {children}
+      </ThemeContext.Provider>
+    );
+  }
+}

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,0 +1,1 @@
+export { ThemeContext, ThemeProvider } from './ThemeContext';

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,15 @@
   --color-tokopedia-green-light: #E8F5E9;
   --color-tokopedia-green-dark: #028A0F;
 
+  /* Dark mode colors */
+  --color-dark-bg-primary: #1a1a1a;
+  --color-dark-bg-secondary: #2d2d2d;
+  --color-dark-bg-tertiary: #3a3a3a;
+  --color-dark-border: #404040;
+  --color-dark-text-primary: #e5e5e5;
+  --color-dark-text-secondary: #a3a3a3;
+  --color-tokopedia-green-dark-mode: #04D415;
+
   /* Custom max-width */
   --max-width-mobile: 428px;
 
@@ -20,7 +29,7 @@
   }
 
   body {
-    @apply bg-gray-100 text-gray-900 m-0 font-sans;
+    @apply bg-gray-100 dark:bg-dark-bg-primary text-gray-900 dark:text-dark-text-primary m-0 font-sans;
   }
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,13 +7,11 @@ import App from './App.tsx'
 (() => {
   try {
     const savedTheme = localStorage.getItem('replicate-ui-theme');
-    if (savedTheme === 'dark') {
-      document.documentElement.classList.add('dark');
-    } else if (savedTheme === 'light') {
-      document.documentElement.classList.remove('dark');
-    } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      document.documentElement.classList.add('dark');
-    }
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const shouldBeDark = savedTheme === 'dark' || (!savedTheme && prefersDark);
+
+    // Use toggle with force parameter for reliable class management
+    document.documentElement.classList.toggle('dark', shouldBeDark);
   } catch (e) {
     // Ignore localStorage errors
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,22 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
+// Initialize theme before React renders to prevent flash
+(() => {
+  try {
+    const savedTheme = localStorage.getItem('replicate-ui-theme');
+    if (savedTheme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else if (savedTheme === 'light') {
+      document.documentElement.classList.remove('dark');
+    } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark');
+    }
+  } catch (e) {
+    // Ignore localStorage errors
+  }
+})();
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,3 +63,10 @@ export interface ChevronIconProps {
 export interface BackArrowIconProps {
   className?: string;
 }
+
+export type Theme = 'light' | 'dark';
+
+export interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,7 @@ export default {
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
+  darkMode: 'class',
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
Implemented a comprehensive dark mode feature for the Replicate UI application:

Features:
- Toggle button in header to switch between light and dark themes
- Theme persistence using localStorage
- System preference detection as fallback
- Smooth theme transitions without flashing

Implementation Details:
- Created ThemeContext using Context API (class component compatible)
- Added ThemeProvider to manage theme state and localStorage
- Configured Tailwind CSS with 'class' dark mode strategy
- Added dark mode color palette (dark-bg-primary, dark-bg-secondary, etc.)
- Updated all components with dark mode variants using Tailwind dark: prefix

Components Updated:
- Header: Added moon/sun icon toggle button
- FeaturedSection: Dark mode backgrounds and text colors
- IconCard: Dark mode container and label colors
- AccordionItem: Dark mode borders, backgrounds, and text
- AccordionList: Dark mode wrapper and empty state
- App: Wrapped with ThemeProvider, added dark backgrounds

New Components:
- MoonIcon: SVG icon for dark mode toggle
- SunIcon: SVG icon for light mode toggle
- ThemeContext: Context provider for theme management

Technical:
- Theme initialization in main.tsx prevents flash of wrong theme
- All components use Tailwind dark: variants for styling
- TypeScript types for Theme and ThemeContextType
- Follows project's class component architecture